### PR TITLE
Upgrade pystac

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     url="https://github.com/azavea/pystac-io",
     license="Apache Software License 2.0",
     packages=find_packages(),
-    install_requires=["pystac>=0.5.2"],
+    install_requires=["pystac>=1.1.0"],
     extras_require={"https": ["requests>=2.24.0"], "s3": ["boto3>=1.16.6"]},
     keywords=["pystac", "pystac_io", "pystac-io", "s3", "catalog", "STAC"],
     classifiers=[


### PR DESCRIPTION
This PR upgrades PySTAC to 1.1.0. The main goal here is to avoid dep conflicts with anything else depending on PySTAC by pulling in anything that PySTAC depends on. That's not much! But there are breaking datamodel changes for consistency with the current STAC version, so it's still nice to get in sync.